### PR TITLE
Fixed sanitizer not working, also added it to the test bin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,21 +15,29 @@ jobs:
     - uses: actions/checkout@v1
     - name: Clone submodules
       run: git submodule update --init --recursive
-    - name: Update
+    - name: Add CMake PPA to get a reasonably updated version of CMake
+      run: |
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+        sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+    - name: Update the local repositories
       run: sudo apt-get update
+    - name: Update CMake
+      run: |
+        sudo apt-get install cmake
+        which cmake
     - name: Install SDL dependencies
       run: sudo apt-get install libsdl2-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev
     - name: Build PR
       if: github.ref != 'master'
       run: |
         cd build
-        cmake ..
+        /usr/bin/cmake ..
         make
     - name: Build master
       if: github.ref == 'master'
       run: |
         cd build
-        cmake --config Release ..
+        /usr/bin/cmake --config Release ..
         make
     - name: C++ check
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,14 +41,20 @@ if(CLANG_TIDY)
     )
 endif()
 
+# Force colors when using ninja with clang
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-fcolor-diagnostics)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(-fdiagnostics-color=always)
+endif()
 
 add_subdirectory(extern/brickengine)
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(src)
 
-option(PACKAGE_TESTS "Build the tests" ON)
-if(PACKAGE_TESTS)
+option(BeastArena_Test "Build the tests" ON)
+if(BeastArena_Test)
     enable_testing()
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13.5)
 project(BeastArena)
 include(CMakePrintHelpers)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,24 +1,14 @@
 file(GLOB_RECURSE BEASTARENALIB_SRC_FILES RELATIVE ${CMAKE_CURRENT_LIST_DIR} *.c[p]*)
 
-## Compiler options
-# Make the compiler complain, a lot
-# Force colors when using ninja with clang
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-fcolor-diagnostics)
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-fdiagnostics-color=always)
-endif()
-# Turn on the address sanitizer for safety checks
-option(BEASTARENALIB_SANITIZER "Turn on the address sanitizer" OFF)
-if(BEASTARENALIB_SANITIZER)
-    add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
-    add_link_options(-fsanitize=address)
-endif()
-add_compile_options(-Wall -Wextra -pedantic -Werror)
 
 add_library(BeastArenaLib STATIC
     ${BEASTARENALIB_SRC_FILES}
 )
+## Compiler options
+# Make the compiler complain, a lot
+target_link_options(BeastArenaLib
+    PRIVATE -Wall -Wextra -pedantic -Werror)
+
 target_link_libraries(BeastArenaLib PUBLIC BrickEngine)
 target_include_directories(BeastArenaLib PUBLIC ${BEASTARENALIB_INCLUDE_DIRECTORY})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,18 +1,23 @@
-## Compiler options
-# Make the compiler complain, a lot
-# Force colors when using ninja with clang
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-fcolor-diagnostics)
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-fdiagnostics-color=always)
-endif()
-add_compile_options(-Wall -Wextra -pedantic -Werror)
-
 add_executable(BeastArena
     main.cpp
 )
+# Make the compiler complain, a lot
+target_compile_options(BeastArena
+    PRIVATE -Wall -Wextra -pedantic -Werror)
+
+# Turn on the address sanitizer for safety checks
+option(BEASTARENA_SANITIZER "Turn on the address sanitizer" OFF)
+if(BEASTARENA_SANITIZER)
+    target_compile_options(BeastArena
+        PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+    target_link_options(BeastArena
+        PRIVATE -fsanitize=address)
+endif()
+
+target_compile_features(BeastArena PUBLIC cxx_std_17)
 target_link_libraries(BeastArena PRIVATE BeastArenaLib)
+
+# Custom targets that work on BeastArena
 add_custom_command(TARGET BeastArena PRE_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_directory
                        ${CMAKE_SOURCE_DIR}/assets/ $<TARGET_FILE_DIR:BeastArena>/assets)
-target_compile_features(BeastArena PUBLIC cxx_std_17)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,13 +3,28 @@ if (NOT TARGET gtest)
 endif()
 
 file(GLOB_RECURSE TEST_FILES RELATIVE ${CMAKE_CURRENT_LIST_DIR} *.c[p]*)
-
 add_executable(BeastArena_Test ${TEST_FILES} ${BEAST_ARENA_SRC_FILES})
+
+## Compiler options
+# Make the compiler complain, a lot
+target_compile_options(BeastArena_Test
+    PRIVATE -Wall -Wextra -pedantic -Werror)
+# Turn on the address sanitizer for safety checks
+option(BEASTARENA_TEST_SANITIZER "Turn on the address sanitizer" OFF)
+if(BEASTARENA_TEST_SANITIZER)
+    target_compile_options(BeastArena_Test
+        PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+    target_link_options(BeastArena_Test
+        PRIVATE -fsanitize=address)
+endif()
+# Linking
 target_link_libraries(BeastArena_Test PRIVATE
     BeastArenaLib
     gtest
     gmock
     gtest_main)
 target_include_directories(BeastArena_Test PRIVATE ${BEASTARENALIB_INCLUDE_DIRECTORY})
+
+# Adding all the tests
 add_test(NAME BeastArena_Test COMMAND BeastArena_Test)
 set_target_properties(BeastArena_Test PROPERTIES FOLDER tests)


### PR DESCRIPTION
# Description

The sanitizer wasn't working with the new test framework. This PR fixes the sanitizer, adds the sanitizer the test binary and adds errors and warnings compiler flags to the test binary. The same fix and changes have been applied to the engine in [this PR](https://github.com/Brick-Studios/BrickEngine/pull/29).

I also updated CMake on Github Actions so that it supports the newer and better commands.

# What I found out during this PR
- The address sanitizer should only be linked to the final binary. See [this source](https://clang.llvm.org/docs/AddressSanitizer.html).
- When adding compiler and linker options, you should use _target_link_options_ and _target_compile_options_ to only add those options to a specific target instead of leaving it to CMake to choose which targets get those options.

# How can this be tested?

Build the project with and without tests, with and without the sanitizer.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Included 1 or more screenshots
- [x] Code is const correct
