### PR TITLE
Resize window entities

### DIFF
--- a/include/controllers/game_controller.hpp
+++ b/include/controllers/game_controller.hpp
@@ -32,8 +32,8 @@ private:
 
     std::vector<int> layers;
 
-    inline static const int SCREEN_HEIGHT = 720;
-    inline static const int SCREEN_WIDTH = 1280;
+    inline static const int SCREEN_HEIGHT = 900;
+    inline static const int SCREEN_WIDTH = 1600;
 };
 
 #endif // FILE_GAME_CONTROLLER_HPP

--- a/include/entities/entity_factory.hpp
+++ b/include/entities/entity_factory.hpp
@@ -15,7 +15,7 @@ public:
     int createPanda(double x, double y, int playerId) const;
     int createGorilla(double x, double y, int playerId) const;
     int createImage(std::string path, int x, int y, int width, int height, Layers layer);
-    int createPlatform(double xScale, double yScale, double x, double y);
+    int createPlatform(double x, double y, double xScale, double yScale);
 private:
     std::shared_ptr<EntityManager> entityManager;
     RenderableFactory& renderableFactory;

--- a/lib/controllers/game_controller.cpp
+++ b/lib/controllers/game_controller.cpp
@@ -46,7 +46,7 @@ void GameController::createTestEntities() {
     entityFactory->createPanda(400, 200, 1);
     entityFactory->createGorilla(1000, 200, 2);
     entityFactory->createImage("backgrounds/forest_watermarked.jpg", SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2, SCREEN_WIDTH, SCREEN_HEIGHT, Layers::Background);
-    entityFactory->createPlatform(640, 500, 720, 20);
+    entityFactory->createPlatform(800, 850, 1400, 10);
 }
 
 void GameController::setupInput() {

--- a/lib/entities/entity_factory.cpp
+++ b/lib/entities/entity_factory.cpp
@@ -14,7 +14,7 @@ int EntityFactory::createPanda(double x, double y, int playerId) const {
     auto r = renderableFactory.createImage(graphicsPath + "beasts/panda/idle-1.png", (int)Layers::Foreground, std::move(dst));
     auto comps = std::make_unique<std::vector<std::unique_ptr<Component>>>();
 
-    comps->push_back(std::make_unique<TransformComponent>(x, y, 125, 200));
+    comps->push_back(std::make_unique<TransformComponent>(x, y, 63, 100));
     comps->push_back(std::make_unique<RectangleColliderComponent>(1, 1, 1));
     comps->push_back(std::make_unique<PhysicsComponent>(100, 0, 0, 0, true, false));
     comps->push_back(std::make_unique<TextureComponent>(std::move(r)));
@@ -28,7 +28,7 @@ int EntityFactory::createGorilla(double x, double y, int playerId) const {
     auto r = renderableFactory.createImage(graphicsPath + "beasts/gorilla/idle-1.png", (int)Layers::Foreground, std::move(dst));
     auto comps = std::make_unique<std::vector<std::unique_ptr<Component>>>();
 
-    comps->push_back(std::make_unique<TransformComponent>(x, y, 100, 200));
+    comps->push_back(std::make_unique<TransformComponent>(x, y, 50, 100));
     comps->push_back(std::make_unique<RectangleColliderComponent>(1, 1, 1));
     comps->push_back(std::make_unique<PhysicsComponent>(100, 0, 0, 0, true, false));
     comps->push_back(std::make_unique<TextureComponent>(std::move(r)));


### PR DESCRIPTION
# Description

The window has been resized to 1600x900. The entities have been resized to 50% of their original size. This allows us to create levels with enough space for some variation. Furthermore, I flipped 2 parameters in the header file which did not correspond to the source file.

## Screenshot(s)
![image](https://user-images.githubusercontent.com/27761285/67670304-eb8dba00-f973-11e9-9a3b-b063fa823d3b.png)

# How can this be tested?

Open the game and check the window and entity sizes.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Included 1 or more screenshots
- [X] Code is const correct
