### PR TITLE
Showcase feedback

### DIFF
--- a/assets/levels/level2.json
+++ b/assets/levels/level2.json
@@ -197,7 +197,7 @@
             "texture_path": "colors/black.jpg",
             "alpha": 255,
             "x": 1270,
-            "y": 600,
+            "y": 640,
             "xScale": 150,
             "yScale": 50
         },
@@ -207,7 +207,7 @@
             "texture_path": "colors/black.jpg",
             "alpha": 255,
             "x": 650,
-            "y": 600,
+            "y": 640,
             "xScale": 150,
             "yScale": 50
         }

--- a/lib/entities/entity_factory.cpp
+++ b/lib/entities/entity_factory.cpp
@@ -27,7 +27,7 @@ int EntityFactory::createGorilla(double x_pos, double y_pos, int player_id) cons
 
     comps->push_back(std::make_unique<TransformComponent>(x_pos, y_pos, 50, 100, Direction::POSITIVE, Direction::POSITIVE));
     comps->push_back(std::make_unique<RectangleColliderComponent>(1, 1, 1, false));
-    comps->push_back(std::make_unique<PhysicsComponent>(105, 0, 0, 0, true, Kinematic::IS_NOT_KINEMATIC, true, false));
+    comps->push_back(std::make_unique<PhysicsComponent>(105, true, 0, 0, true, Kinematic::IS_NOT_KINEMATIC, true, false));
     comps->push_back(std::make_unique<TextureComponent>(std::move(r)));
     comps->push_back(std::make_unique<PlayerComponent>(player_id));
     comps->push_back(std::make_unique<HealthComponent>(100, [](int entity_id) {
@@ -44,7 +44,7 @@ int EntityFactory::createPanda1(double x_pos, double y_pos, int player_id) const
 
     comps->push_back(std::make_unique<TransformComponent>(x_pos, y_pos, 63, 100, Direction::POSITIVE, Direction::POSITIVE));
     comps->push_back(std::make_unique<RectangleColliderComponent>(1, 1, 1, false));
-    comps->push_back(std::make_unique<PhysicsComponent>(100, 0, 0, 0, true, Kinematic::IS_NOT_KINEMATIC, true, false));
+    comps->push_back(std::make_unique<PhysicsComponent>(100, true, 0, 0, true, Kinematic::IS_NOT_KINEMATIC, true, false));
     comps->push_back(std::make_unique<TextureComponent>(std::move(r)));
     comps->push_back(std::make_unique<PlayerComponent>(player_id));
     comps->push_back(std::make_unique<ClickComponent>([]() -> void {
@@ -67,7 +67,7 @@ int EntityFactory::createPanda2(double x_pos, double y_pos, int player_id) const
 
     comps->push_back(std::make_unique<TransformComponent>(x_pos, y_pos, 63, 100, Direction::POSITIVE, Direction::POSITIVE));
     comps->push_back(std::make_unique<RectangleColliderComponent>(1, 1, 1, false));
-    comps->push_back(std::make_unique<PhysicsComponent>(100, 0, 0, 0, true, Kinematic::IS_NOT_KINEMATIC, true, false));
+    comps->push_back(std::make_unique<PhysicsComponent>(100, true, 0, 0, true, Kinematic::IS_NOT_KINEMATIC, true, false));
     comps->push_back(std::make_unique<TextureComponent>(std::move(r)));
     comps->push_back(std::make_unique<PlayerComponent>(player_id));
     comps->push_back(std::make_unique<ClickComponent>([]() -> void {
@@ -90,7 +90,7 @@ int EntityFactory::createPanda3(double x_pos, double y_pos, int player_id) const
 
     comps->push_back(std::make_unique<TransformComponent>(x_pos, y_pos, 63, 100, Direction::POSITIVE, Direction::POSITIVE));
     comps->push_back(std::make_unique<RectangleColliderComponent>(1, 1, 1, false));
-    comps->push_back(std::make_unique<PhysicsComponent>(100, 0, 0, 0, true, Kinematic::IS_NOT_KINEMATIC, true, false));
+    comps->push_back(std::make_unique<PhysicsComponent>(100, true, 0, 0, true, Kinematic::IS_NOT_KINEMATIC, true, false));
     comps->push_back(std::make_unique<TextureComponent>(std::move(r)));
     comps->push_back(std::make_unique<PlayerComponent>(player_id));
     comps->push_back(std::make_unique<ClickComponent>([]() -> void {
@@ -117,7 +117,7 @@ int EntityFactory::createWeapon(double x_pos, double y_pos, bool ammo) const {
 
     comps->push_back(std::make_unique<TransformComponent>(x_pos, y_pos, 31, 22, Direction::POSITIVE, Direction::POSITIVE));
     comps->push_back(std::make_unique<RectangleColliderComponent>(1, 1, 1, true));
-    comps->push_back(std::make_unique<PhysicsComponent>(50, 0, 0, 0, true, Kinematic::IS_NOT_KINEMATIC, true, true));
+    comps->push_back(std::make_unique<PhysicsComponent>(50, false, 0, 0, true, Kinematic::IS_NOT_KINEMATIC, true, true));
     comps->push_back(std::make_unique<TextureComponent>(std::move(weapon_r)));
     comps->push_back(std::make_unique<PickupComponent>());
     comps->push_back(std::make_unique<WeaponComponent>(

--- a/lib/entities/entity_factory.cpp
+++ b/lib/entities/entity_factory.cpp
@@ -121,11 +121,11 @@ int EntityFactory::createWeapon(double x_pos, double y_pos, bool ammo) const {
     comps->push_back(std::make_unique<TextureComponent>(std::move(weapon_r)));
     comps->push_back(std::make_unique<PickupComponent>());
     comps->push_back(std::make_unique<WeaponComponent>(
-        DamageComponent(10),
+        DamageComponent(25),
         TextureComponent(std::move(bullet_r)),
-        PhysicsComponent(1, 0, 4500, 0, false, Kinematic::IS_NOT_KINEMATIC, false, false),
+        PhysicsComponent(1, 0, 2250, 0, false, Kinematic::IS_NOT_KINEMATIC, false, false),
         DespawnComponent(true, true),
-        Scale(9, 3),
+        Scale(18, 6),
         0.2, ammoOpt));
 
     return entityManager->createEntity(std::move(comps), std::nullopt);

--- a/lib/scenes/scene_manager.cpp
+++ b/lib/scenes/scene_manager.cpp
@@ -42,6 +42,8 @@ void SceneManager::loadLevel(Level& level) {
             current_scene_entities.push_back(entity_factory->createPlatform(x, y, xScale, yScale, platform.texture_path, platform.alpha));
         }
     }
+
+    engine->toggleCursor(false);
 }
 
 void SceneManager::loadMenu(Menu& menu) {
@@ -59,6 +61,8 @@ void SceneManager::loadMenu(Menu& menu) {
     for(Image image : menu.images) {
         current_scene_entities.push_back(entity_factory->createImage(image.texture_path, image.x / menu.relative_modifier, image.y / menu.relative_modifier, image.x_scale / menu.relative_modifier, image.y_scale / menu.relative_modifier, Layers::Middleground, image.alpha));
     }
+
+    engine->toggleCursor(true);
 }
 
 void SceneManager::destroyCurrentScene() {


### PR DESCRIPTION
# Description

I made the FPS counter green for better contrast, made the cursor disappear when a level is loaded (feedback Bob) and added "horizontal gravity" when a player is jumping or falling. Oh and I changed the level again because my changes do not get merged :S

[This PR needs to be combined with this PR from the engine](https://github.com/Brick-Studios/BrickEngine/pull/46)

## Screenshot(s)
![image](https://user-images.githubusercontent.com/27761285/69232347-2f4a9c80-0b8b-11ea-94ff-8c58502bff4d.png)
_prettyirrelevant.png_

# How can this be tested?

Please verify these 4 changes

- [x] The FPS counter is green
- [x] The cursor is still visible in the menu
- [x] The cursor is not visible when the level is loaded
- [x] The gorilla can jump up on the platform from one of the middle poles

**PLEASE NOTE!**
Enabling performance debugging breaks this! Please test with performance debugging disabled
- [ ] The player has less in-air movement

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Included 1 or more screenshots
- [x] Code is const correct
