### PR TITLE
Highscore scrolling fix

### DIFF
--- a/lib/systems/highscore_system.cpp
+++ b/lib/systems/highscore_system.cpp
@@ -20,7 +20,6 @@ void HighscoreSystem::update(double) {
         else {
             auto score = scores.at(selector);
             createHighscores(score.first, score.second);
-            selector++;
             initialized = true;
         }
     }

--- a/lib/systems/highscore_system.cpp
+++ b/lib/systems/highscore_system.cpp
@@ -29,18 +29,18 @@ void HighscoreSystem::update(double) {
         int x = input.checkInput(1, PlayerInput::X_AXIS);
         if(x > 0) {
             entityManager->removeEntitiesWithTag("HighscoreScene_player");
-            auto score = scores.at(selector);
-            createHighscores(score.first, score.second);
             selector++;
             if (selector > scores.size() - 1)
                 selector = 0;
-        } else if(x < 0) {
-            entityManager->removeEntitiesWithTag("HighscoreScene_player");
             auto score = scores.at(selector);
             createHighscores(score.first, score.second);
+        } else if(x < 0) {
+            entityManager->removeEntitiesWithTag("HighscoreScene_player");
             selector--;
             if (selector < 0)
                 selector = scores.size() - 1;
+            auto score = scores.at(selector);
+            createHighscores(score.first, score.second);
         }
     }
 }


### PR DESCRIPTION
# Description

Fixed highscore
Issue: https://github.com/Brick-Studios/BeastArena/issues/60
# How can this be tested?

Test highscore scrolling (if it goes in correct order)
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Included 1 or more screenshots
- [x] Code is const correct
