### PR TITLE
Layer and pause music fix.

### DIFF
--- a/lib/scenes/end_scene.cpp
+++ b/lib/scenes/end_scene.cpp
@@ -49,14 +49,14 @@ void EndScene::performPrepare() {
     player_spawns.push_back({ 1700, 500});
 
     // Spawn the trophy
-    entity_components->push_back(factory.createTrophy(WIDTH / 2, 400, 50, 75, getRelativeModifier(), Layers::Middleground, 255));
+    entity_components->push_back(factory.createTrophy(WIDTH / 2, 400, 50, 75, getRelativeModifier(), Layers::Gadgets, 255));
 
 
     auto& em = factory.getEntityManager();
     auto entities_with_player = em.getEntitiesByComponent<PlayerComponent>();
     // Spawn the signs (there are always 2)
-    entity_components->push_back(factory.createReadySign(200, 980, 100, 50, getRelativeModifier(), Layers::Foreground, 255));
-    entity_components->push_back(factory.createReadySign(300, 980, 100, 50, getRelativeModifier(), Layers::Foreground, 255));
+    entity_components->push_back(factory.createReadySign(200, 980, 100, 50, getRelativeModifier(), Layers::Gadgets, 255));
+    entity_components->push_back(factory.createReadySign(300, 980, 100, 50, getRelativeModifier(), Layers::Gadgets, 255));
     if(entities_with_player.size() > 2) {
         entity_components->push_back(factory.createReadySign(1720, 980, 100, 50, getRelativeModifier(), Layers::Foreground, 255));
         if(entities_with_player.size() > 3)

--- a/lib/scenes/pause_scene.cpp
+++ b/lib/scenes/pause_scene.cpp
@@ -28,8 +28,10 @@ void PauseScene::performPrepare(){
 }
 
 void PauseScene::start() {
+    engine.getSoundManager().toggleMusic(true);
 }
 
 void PauseScene::leave() {
     engine.toggleCursor(false);
+    engine.getSoundManager().toggleMusic(false);
 }


### PR DESCRIPTION
# Description

Fixes an issue with the layering of the trophy and the skips signs in the end game scene by putting them on the same layer as the gadgets. Other issues which is fixed is the music pauses when the game is paused

# How can this be tested?

- [ ] Pause the game and check whether the game is actually paused.
- [ ] Check whether the signs are shown correctly in the player's hands.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] Included 1 or more screenshots
- [X] Code is const correct
